### PR TITLE
Removed space in node name for Oracle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
     node {
-        name "O=Oracle ,L=New York,C=US"
+        name "O=Oracle,L=New York,C=US"
         p2pPort 10011
         rpcSettings {
             address("localhost:10012")


### PR DESCRIPTION
This extra space issue was causing a deployNodes build error on Windows.  After removing space, now the build works. 
Before change: 
* What went wrong:
Execution failed for task ':deployNodes'.
> Trailing char < > at index 20: .\build\nodes\Oracle