### PR TITLE
Update type safe config to latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ crashlytics-build.properties
 
 # docs related
 docs/virtualenv/
+
+# local publish scripts
+publish/

--- a/modules/manual/build.gradle
+++ b/modules/manual/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     cordaCompile project(":cordapp")
 
     // Typesafe config.
-    compile 'com.typesafe:config:1.2.1'
+    compile 'com.typesafe:config:1.3.4'
 
     // gson
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5"

--- a/modules/ripple/build.gradle
+++ b/modules/ripple/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile 'com.ripple:ripple-core:0.0.1-SNAPSHOT'
 
     // Typesafe config.
-    compile 'com.typesafe:config:1.2.1'
+    compile 'com.typesafe:config:1.3.4'
 
     // Project dependencies.
     cordaCompile project(":cordapp")

--- a/modules/swift/build.gradle
+++ b/modules/swift/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     cordaCompile project(":cordapp")
 
     // Typesafe config.
-    compile 'com.typesafe:config:1.2.1'
+    compile 'com.typesafe:config:1.3.4'
 
     // gson
     compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.5"


### PR DESCRIPTION
I needed this so it works with our client which expects a newer version of typesafe config. Since the fat jars contains all the libraries, it can interfere with other code that uses typesafe config.

Also created some script to publish to our local repo and added directory to .gitignore