### PR TITLE
Feature/manual payment reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,9 @@ lib/dokka.jar
 cordapp/out/
 cordapp-contracts-states/out/
 oracle/out/
-ripple/out/
-swift/out/
-manual/out/
+modules/ripple/out/
+modules/swift/out/
+modules/manual/out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
+++ b/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
@@ -7,6 +7,7 @@ import com.r3.corda.finance.obligation.contracts.states.Obligation
 import com.r3.corda.lib.tokens.contracts.types.TokenType
 import net.corda.confidential.SwapIdentitiesFlow
 import net.corda.core.contracts.Amount
+import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
@@ -37,7 +38,8 @@ object CreateObligation {
             private val role: InitiatorRole,
             private val counterparty: Party,
             private val dueBy: Instant? = null,
-            private val anonymous: Boolean = true
+            private val anonymous: Boolean = true,
+            private val externalId: String? = null
     ) : FlowLogic<WireTransaction>() {
 
         companion object {
@@ -73,8 +75,8 @@ object CreateObligation {
         private fun createObligation(us: AbstractParty, them: AbstractParty): Pair<Obligation<T>, PublicKey> {
             check(us != them) { "You cannot create an obligation to yourself" }
             val obligation = when (role) {
-                InitiatorRole.OBLIGEE -> Obligation(amount, them, us, dueBy)
-                InitiatorRole.OBLIGOR -> Obligation(amount, us, them, dueBy)
+                InitiatorRole.OBLIGEE -> Obligation(amount, them, us, dueBy, linearId = UniqueIdentifier(externalId = externalId))
+                InitiatorRole.OBLIGOR -> Obligation(amount, us, them, dueBy, linearId = UniqueIdentifier(externalId = externalId))
             }
             return Pair(obligation, us.owningKey)
         }


### PR DESCRIPTION
Needed to be able to pass in a payment reference to the MakeManualPayment flow. Not sure if this is the best way but it doesn't affect the other payment flows.

Also, allows the passing of an external id to CreateObligation which is stored in the externalId field of the obligation's UniqueIdentifier.