### PR TITLE
Feature/configurable timewindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,9 @@ lib/dokka.jar
 cordapp/out/
 cordapp-contracts-states/out/
 oracle/out/
-ripple/out/
-swift/out/
-manual/out/
+modules/ripple/out/
+modules/swift/out/
+modules/manual/out/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
+++ b/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
@@ -18,6 +18,7 @@ import net.corda.core.utilities.ProgressTracker
 import net.corda.core.utilities.seconds
 import net.corda.core.utilities.unwrap
 import java.security.PublicKey
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -37,7 +38,8 @@ object CreateObligation {
             private val role: InitiatorRole,
             private val counterparty: Party,
             private val dueBy: Instant? = null,
-            private val anonymous: Boolean = true
+            private val anonymous: Boolean = true,
+            private val timeLimit: Duration? = null
     ) : FlowLogic<WireTransaction>() {
 
         companion object {
@@ -108,7 +110,7 @@ object CreateObligation {
                 addOutputState(obligation, ObligationContract.CONTRACT_REF)
                 val signers = obligation.participants.map { it.owningKey }
                 addCommand(ObligationCommands.Create(), signers)
-                setTimeWindow(serviceHub.clock.instant(), 30.seconds)
+                if (timeLimit != null) setTimeWindow(serviceHub.clock.instant(), timeLimit)
             }
 
             // Step 4. Sign the transaction.

--- a/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
+++ b/cordapp/src/main/kotlin/com/r3/corda/finance/obligation/workflows/flows/CreateObligation.kt
@@ -111,6 +111,7 @@ object CreateObligation {
                 val signers = obligation.participants.map { it.owningKey }
                 addCommand(ObligationCommands.Create(), signers)
                 if (timeLimit != null) setTimeWindow(serviceHub.clock.instant(), timeLimit)
+                else setTimeWindow(serviceHub.clock.instant(), 30.seconds)
             }
 
             // Step 4. Sign the transaction.


### PR DESCRIPTION
When using Corda settler on a busy server, we sometimes exceed the hard-coded 30 second time window in the CreateObligation flow. This PR makes that time window configurable. Original 30 second time limit is retained in the case no time limit is passed in to the flow, just to maintain previous behaviour.